### PR TITLE
spec: Rebuild on openssl-3

### DIFF
--- a/SPECS/rsync.spec
+++ b/SPECS/rsync.spec
@@ -8,7 +8,7 @@
 Summary: A program for synchronizing files over a network
 Name: rsync
 Version: 3.4.1
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 URL: https://rsync.samba.org/
 
 Source0: rsync-3.4.1.tar.gz
@@ -113,6 +113,9 @@ install -D -m644 %{SOURCE6} $RPM_BUILD_ROOT/%{_unitdir}/rsyncd@.service
 %systemd_postun_with_restart rsyncd.service
 
 %changelog
+* Thu Jan 08 2026 Philippe Coval <philippe.coval@vates.tech> - 3.4.1-1.2
+- Rebuild on openssl-3
+
 * Fri Apr 25 2025 Thierry Escande <thierry.escande@vates.tech> - 3.4.1-1.1
 - Set noreplace flag for /etc/rsyncd.conf file
 


### PR DESCRIPTION
Build was tested on xcp-ng-8.3, with following deps:

  Requires: ... libcrypto.so.3(OPENSSL_3.0.0)(64bit) ...

There is no need to merge rsync-3.4.1-4.xs8.src.rpm with:

   CP-53393: Remove build dependency on libzstd-devel for Yangtze

xcp-ng-8.3 does not need this

Relate-to: https://github.com/xcp-ng-rpms/rsync/pull/3#pullrequestreview-3172677459


- [x] Koji build Scratch (v8.3-incoming): https://koji.xcp-ng.org/taskinfo?taskID=93698
- [x] Koji build (v8.3-u-pcoval1) : https://koji.xcp-ng.org/taskinfo?taskID=93706# openssl-devel-1.0.2k-26.2.xcpng8.3.x86_64
- [x] Koji build (v8.3-u-pcoval2) : https://koji.xcp-ng.org/taskinfo?taskID=93708# openssl-devel-3.0.9-2.0.1.2.xcpng8.3.x86_64
